### PR TITLE
Description: Updates to fio_runner.sh

### DIFF
--- a/fio/fio_runner.sh
+++ b/fio/fio_runner.sh
@@ -9,7 +9,7 @@
 #######################################################################################################################
 
 TEST_TEMPLATES="Basic"
-TEST_DURATION=60
+TEST_DURATION=300
 TEST_DIR="datadir1"
 IS_LOCAL_DIR=1
 
@@ -76,7 +76,7 @@ echo -e "Running $TEST_TEMPLATES Workloads\n"
 for i in `ls templates/${TEST_TEMPLATES}/ | cut -d "/" -f 3`
 do
  echo "######## Starting workload -- $i#######"
- fio --eta-newline=2s templates/${TEST_TEMPLATES}/$i 
+ fio --eta-newline=1s templates/${TEST_TEMPLATES}/$i 
  echo "######## Ended workload -- $i#######"
 done  
 


### PR DESCRIPTION
----------------------------------------------------------------------------------------

- Increased default fio run duration to 300s
  (Will help depicting I/O during demo runs using docker logs -f by making container live longer)

- Reduced console o/p duration to 1s instead of 2s
  (Increase  granularity of I/O progress) 