### PR TITLE
Include container to run database load for mysql (mysql-client)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,7 +70,17 @@ _push_k8s_client_image:
 
 k8s-client: deps _build_k8s_client_image _push_k8s_client_image
 
-build: deps vdbench fio iometer k8s-client
+_build_tests_mysql_client_image:
+	@echo "INFO: Building container image for performing mysql tests"
+	cd mysql-client && docker build -t openebs/tests-mysql-client .
+
+_push_tests_mysql_client_image:
+	@echo "INFO: Publish container (openebs/tests-mysql-client)"
+	cd mysql-client/buildscripts && ./push
+
+mysql-client: deps _build_tests_mysql_client_image _push_tests_mysql_client_image
+
+build: deps vdbench fio iometer k8s-client mysql-client
 
 
 #

--- a/mysql-client/Dockerfile
+++ b/mysql-client/Dockerfile
@@ -1,0 +1,5 @@
+FROM ubuntu
+MAINTAINER OpenEBS
+RUN apt-get update
+RUN apt-get install -y mysql-client timelimit 
+COPY MySQLLoadGenerate.sh /

--- a/mysql-client/MySQLLoadGenerate.sh
+++ b/mysql-client/MySQLLoadGenerate.sh
@@ -1,0 +1,26 @@
+#! /bin/sh
+
+MySQLDump()
+{
+while true
+do
+ mysql -uroot -pk8sDem0 -h $pod_ip -e "INSERT INTO Hardware select * FROM Hardware;" Inventory
+ sleep 2
+done
+}
+
+PrepareMySQL()
+{
+mysql -uroot -pk8sDem0 -h $pod_ip -e "CREATE DATABASE Inventory;"
+
+mysql -uroot -pk8sDem0 -h $pod_ip -e \
+"CREATE TABLE Hardware (Name VARCHAR(20),HWtype VARCHAR(20),Model VARCHAR(20));" Inventory 
+
+mysql -uroot -pk8sDem0 -h $pod_ip -e \
+"INSERT INTO Hardware (Name,HWtype,Model) VALUES ('TestBox','Server','DellR820');" Inventory
+}
+
+pod_ip=$1
+PrepareMySQL;
+MySQLDump; 
+

--- a/mysql-client/buildscripts/push
+++ b/mysql-client/buildscripts/push
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+IMAGEID=$( docker images -q openebs/tests-mysql-client )
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+then 
+  docker login -u "${DNAME}" -p "${DPASS}"; 
+  #Push to docker hub repository with latest tag
+  docker tag ${IMAGEID} openebs/tests-mysql-client:latest
+  docker push openebs/tests-mysql-client:latest; 
+else
+  echo "No docker credentials provided. Skip uploading openebs/tests-mysql-client:latest to docker hub"; 
+fi;


### PR DESCRIPTION
Code changes: 
----------------
- Why is this change necessary?

  We need a client to generate sql load for DB servers deployed on kubernetes

- How does this change address the issue?

  Creates a client container that runs some simple insert/select queries repeatedly with increased data chunks each time to generate load on the sql server pod

- What side effects does this change have?
  
   No impact to the product itself

Changes tested on: 
---------------------
Container tested after building locally on ubuntu 16.04 64 bit Baremetal boxes/ESX VM