### PR TITLE
Create a custom percona server container image integrated with pmm-client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,17 @@ _push_tests_tpcc_client_image:
 
 tpcc-client: deps _build_tests_tpcc_client_image _push_tests_tpcc_client_image
 
-build: deps vdbench fio iometer k8s-client mysql-client tpcc-client
+_build_tests_custom_percona_image:
+	@echo "INFO: Building container image for integrating pmm with percona"
+	cd custom-percona && docker build -t openebs/tests-custom-percona .
+
+_push_tests_custom_percona_image:
+	@echo "INFO: Publish container (openebs/tests-custom-percona)"
+	cd custom-percona/buildscripts && ./push
+
+custom-percona: deps _build_tests_custom_percona_image _push_tests_custom_percona_image
+
+build: deps vdbench fio iometer k8s-client mysql-client tpcc-client custom-percona
 
 
 #

--- a/custom-percona/Dockerfile
+++ b/custom-percona/Dockerfile
@@ -1,0 +1,104 @@
+# vim:set ft=dockerfile:
+FROM debian:jessie
+
+# add our user and group first to make sure their IDs get assigned consistently, regardless of whatever dependencies get added
+RUN groupadd -r mysql && useradd -r -g mysql mysql
+
+# add gosu for easy step-down from root
+ENV GOSU_VERSION 1.7
+RUN set -x \
+	&& apt-get update && apt-get install -y --no-install-recommends ca-certificates wget && rm -rf /var/lib/apt/lists/* \
+	&& wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)" \
+	&& wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc" \
+	&& export GNUPGHOME="$(mktemp -d)" \
+	&& gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4 \
+	&& gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu \
+	&& rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc \
+	&& chmod +x /usr/local/bin/gosu \
+	&& gosu nobody true \
+	&& apt-get purge -y --auto-remove ca-certificates wget
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+# install "pwgen" for randomizing passwords
+# install "apt-transport-https" for Percona's repo (switched to https-only)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+		apt-transport-https ca-certificates \
+		pwgen \
+	&& rm -rf /var/lib/apt/lists/*
+
+ENV GPG_KEYS \
+# pub   1024D/CD2EFD2A 2009-12-15
+#       Key fingerprint = 430B DF5C 56E7 C94E 848E  E60C 1C4C BDCD CD2E FD2A
+# uid                  Percona MySQL Development Team <mysql-dev@percona.com>
+# sub   2048g/2D607DAF 2009-12-15
+	430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A \
+# pub   4096R/8507EFA5 2016-06-30
+#       Key fingerprint = 4D1B B29D 63D9 8E42 2B21  13B1 9334 A25F 8507 EFA5
+# uid                  Percona MySQL Development Team (Packaging key) <mysql-dev@percona.com>
+# sub   4096R/4CAC6D72 2016-06-30
+	4D1BB29D63D98E422B2113B19334A25F8507EFA5
+RUN set -ex; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	for key in $GPG_KEYS; do \
+		gpg --keyserver ha.pool.sks-keyservers.net --recv-keys "$key"; \
+	done; \
+	gpg --export $GPG_KEYS > /etc/apt/trusted.gpg.d/percona.gpg; \
+	rm -r "$GNUPGHOME"; \
+	apt-key list
+
+RUN echo 'deb https://repo.percona.com/apt jessie main' > /etc/apt/sources.list.d/percona.list
+
+ENV PERCONA_MAJOR 5.7
+ENV PERCONA_VERSION 5.7.19-17-1.jessie
+
+# the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
+# also, we set debconf keys to make APT a little quieter
+RUN { \
+		for key in \
+			percona-server-server/root_password \
+			percona-server-server/root_password_again \
+			"percona-server-server-$PERCONA_MAJOR/root-pass" \
+			"percona-server-server-$PERCONA_MAJOR/re-root-pass" \
+		; do \
+			echo "percona-server-server-$PERCONA_MAJOR" "$key" password 'unused'; \
+		done; \
+	} | debconf-set-selections \
+	&& apt-get update \
+	&& apt-get install -y \
+		percona-server-server-$PERCONA_MAJOR=$PERCONA_VERSION \
+	&& rm -rf /var/lib/apt/lists/* \
+# comment out any "user" entires in the MySQL config ("docker-entrypoint.sh" or "--user" will handle user switching)
+	&& sed -ri 's/^user\s/#&/' /etc/mysql/my.cnf \
+# purge and re-create /var/lib/mysql with appropriate ownership
+	&& rm -rf /var/lib/mysql && mkdir -p /var/lib/mysql /var/run/mysqld \
+	&& chown -R mysql:mysql /var/lib/mysql /var/run/mysqld \
+# ensure that /var/run/mysqld (used for socket and lock files) is writable regardless of the UID our mysqld instance ends up having at runtime
+	&& chmod 777 /var/run/mysqld
+
+# comment out a few problematic configuration values
+# don't reverse lookup hostnames, they are usually another container
+RUN \
+	find /etc/mysql/ -name '*.cnf' -print0 \
+		| xargs -0 grep -lZE '^(bind-address|log)' \
+		| xargs -0 sed -Ei 's/^(bind-address|log)/#&/' \
+	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
+
+VOLUME ["/var/lib/mysql", "/var/log/mysql"]
+
+# Start of changes to include pmm-client
+RUN apt-get update && apt-get install -y wget dpkg 
+
+RUN wget https://repo.percona.com/apt/percona-release_0.1-4.jessie_all.deb \
+    && dkpg -i percona-release_0.1-4.jessie_all.deb || true \ 
+    && apt-get install -y -f
+
+RUN apt-get update && apt-get install pmm-client
+# End of changes to include pmm-client
+
+COPY docker-entrypoint.sh /usr/local/bin/
+RUN ln -s usr/local/bin/docker-entrypoint.sh / # backwards compat
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+EXPOSE 3306
+CMD ["mysqld"]

--- a/custom-percona/buildscripts/push
+++ b/custom-percona/buildscripts/push
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+IMAGEID=$( docker images -q openebs/tests-custom-percona )
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+then 
+  docker login -u "${DNAME}" -p "${DPASS}"; 
+  #Push to docker hub repository with latest tag
+  docker tag ${IMAGEID} openebs/tests-custom-percona:latest
+  docker push openebs/tests-custom-percona:latest; 
+else
+  echo "No docker credentials provided. Skip uploading openebs/tests-custom-percona:latest to docker hub"; 
+fi;

--- a/custom-percona/docker-entrypoint.sh
+++ b/custom-percona/docker-entrypoint.sh
@@ -1,0 +1,177 @@
+#!/bin/bash
+set -eo pipefail
+shopt -s nullglob
+
+# if command starts with an option, prepend mysqld
+if [ "${1:0:1}" = '-' ]; then
+	set -- mysqld "$@"
+fi
+
+# skip setup if they want an option that stops mysqld
+wantHelp=
+for arg; do
+	case "$arg" in
+		-'?'|--help|--print-defaults|-V|--version)
+			wantHelp=1
+			break
+			;;
+	esac
+done
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+_check_config() {
+	toRun=( "$@" --verbose --help )
+	if ! errors="$("${toRun[@]}" 2>&1 >/dev/null)"; then
+		cat >&2 <<-EOM
+
+			ERROR: mysqld failed while attempting to check config
+			command was: "${toRun[*]}"
+
+			$errors
+		EOM
+		exit 1
+	fi
+}
+
+_datadir() {
+	"$@" --verbose --help 2>/dev/null | awk '$1 == "datadir" { print $2; exit }'
+}
+
+# allow the container to be started with `--user`
+if [ "$1" = 'mysqld' -a -z "$wantHelp" -a "$(id -u)" = '0' ]; then
+	_check_config "$@"
+	DATADIR="$(_datadir "$@")"
+	mkdir -p "$DATADIR"
+	chown -R mysql:mysql "$DATADIR"
+	exec gosu mysql "$BASH_SOURCE" "$@"
+fi
+
+if [ "$1" = 'mysqld' -a -z "$wantHelp" ]; then
+	# still need to check config, container may have started with --user
+	_check_config "$@"
+	# Get config
+	DATADIR="$(_datadir "$@")"
+
+	if [ ! -d "$DATADIR/mysql" ]; then
+		file_env 'MYSQL_ROOT_PASSWORD'
+		if [ -z "$MYSQL_ROOT_PASSWORD" -a -z "$MYSQL_ALLOW_EMPTY_PASSWORD" -a -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+			echo >&2 'error: database is uninitialized and password option is not specified '
+			echo >&2 '  You need to specify one of MYSQL_ROOT_PASSWORD, MYSQL_ALLOW_EMPTY_PASSWORD and MYSQL_RANDOM_ROOT_PASSWORD'
+			exit 1
+		fi
+
+		mkdir -p "$DATADIR"
+
+		echo 'Initializing database'
+		"$@" --initialize-insecure
+		echo 'Database initialized'
+
+		"$@" --skip-networking --socket=/var/run/mysqld/mysqld.sock &
+		pid="$!"
+
+		mysql=( mysql --protocol=socket -uroot -hlocalhost --socket=/var/run/mysqld/mysqld.sock )
+
+		for i in {30..0}; do
+			if echo 'SELECT 1' | "${mysql[@]}" &> /dev/null; then
+				break
+			fi
+			echo 'MySQL init process in progress...'
+			sleep 1
+		done
+		if [ "$i" = 0 ]; then
+			echo >&2 'MySQL init process failed.'
+			exit 1
+		fi
+
+		if [ -z "$MYSQL_INITDB_SKIP_TZINFO" ]; then
+			# sed is for https://bugs.mysql.com/bug.php?id=20545
+			mysql_tzinfo_to_sql /usr/share/zoneinfo | sed 's/Local time zone must be set--see zic manual page/FCTY/' | "${mysql[@]}" mysql
+		fi
+
+		if [ ! -z "$MYSQL_RANDOM_ROOT_PASSWORD" ]; then
+			export MYSQL_ROOT_PASSWORD="$(pwgen -1 32)"
+			echo "GENERATED ROOT PASSWORD: $MYSQL_ROOT_PASSWORD"
+		fi
+		"${mysql[@]}" <<-EOSQL
+			-- What's done in this file shouldn't be replicated
+			--  or products like mysql-fabric won't work
+			SET @@SESSION.SQL_LOG_BIN=0;
+
+			DELETE FROM mysql.user ;
+			CREATE USER 'root'@'%' IDENTIFIED BY '${MYSQL_ROOT_PASSWORD}' ;
+			GRANT ALL ON *.* TO 'root'@'%' WITH GRANT OPTION ;
+			DROP DATABASE IF EXISTS test ;
+			FLUSH PRIVILEGES ;
+		EOSQL
+
+		if [ ! -z "$MYSQL_ROOT_PASSWORD" ]; then
+			mysql+=( -p"${MYSQL_ROOT_PASSWORD}" )
+		fi
+
+		file_env 'MYSQL_DATABASE'
+		if [ "$MYSQL_DATABASE" ]; then
+			echo "CREATE DATABASE IF NOT EXISTS \`$MYSQL_DATABASE\` ;" | "${mysql[@]}"
+			mysql+=( "$MYSQL_DATABASE" )
+		fi
+
+		file_env 'MYSQL_USER'
+		file_env 'MYSQL_PASSWORD'
+		if [ "$MYSQL_USER" -a "$MYSQL_PASSWORD" ]; then
+			echo "CREATE USER '$MYSQL_USER'@'%' IDENTIFIED BY '$MYSQL_PASSWORD' ;" | "${mysql[@]}"
+
+			if [ "$MYSQL_DATABASE" ]; then
+				echo "GRANT ALL ON \`$MYSQL_DATABASE\`.* TO '$MYSQL_USER'@'%' ;" | "${mysql[@]}"
+			fi
+
+			echo 'FLUSH PRIVILEGES ;' | "${mysql[@]}"
+		fi
+
+		echo
+		for f in /docker-entrypoint-initdb.d/*; do
+			case "$f" in
+				*.sh)     echo "$0: running $f"; . "$f" ;;
+				*.sql)    echo "$0: running $f"; "${mysql[@]}" < "$f"; echo ;;
+				*.sql.gz) echo "$0: running $f"; gunzip -c "$f" | "${mysql[@]}"; echo ;;
+				*)        echo "$0: ignoring $f" ;;
+			esac
+			echo
+		done
+
+		if [ ! -z "$MYSQL_ONETIME_PASSWORD" ]; then
+			"${mysql[@]}" <<-EOSQL
+				ALTER USER 'root'@'%' PASSWORD EXPIRE;
+			EOSQL
+		fi
+		if ! kill -s TERM "$pid" || ! wait "$pid"; then
+			echo >&2 'MySQL init process failed.'
+			exit 1
+		fi
+
+		echo
+		echo 'MySQL init process done. Ready for start up.'
+		echo
+	fi
+fi
+
+exec "$@"


### PR DESCRIPTION
Code changes: 
----------------

- PMM (Percona monitoring & management) is a free and open-source solution that provides thorough time-based analysis for MySQL servers.

  It consists of :

  a) pmm-client : Which is installed on every database host that you want to monitor. It collects server metrics, general system metrics, and query analytics data for a complete performance overview.

  b) pmm-server : The central part of PMM that aggregates collected data and presents it in the form of tables, dashboards, and graphs in a web interface.

- While the pmm-server is available as a standalone docker image, the pmm-client installation on the DB server is a manual process. While acceptable for a bare-metal DB installation, it is not optimal for a percona server container, as the packages in a container are best included in the image (immutable nature of docker containers)

- This commit addresses the above case and integrates the pmm-client installation steps into the percona server dockerfile to create a custom-percona image that comes with pmm-client integrated.

   Note: The process of registering to a running pmm-server will still be a manual process that needs to be run __inside__ the container.

Changes tested on:
---------------------
Container tested after building locally on ubuntu 16.04 64 bit Baremetal boxes/ESX VM