### PR TITLE
Generate random server-id for mysql-slave 

### DIFF
--- a/mysql-slave/Dockerfile
+++ b/mysql-slave/Dockerfile
@@ -65,7 +65,7 @@ RUN { \
 RUN sed -Ei 's/^(bind-address|log)/#&/' /etc/mysql/mysql.conf.d/mysqld.cnf \
 	&& echo '[mysqld]\nskip-host-cache\nskip-name-resolve' > /etc/mysql/conf.d/docker.cnf
 
-RUN sed -i '/\[mysqld\]/a server-id=1\nlog-bin' /etc/mysql/mysql.conf.d/mysqld.cnf
+#RUN sed -i '/\[mysqld\]/a server-id=1\nlog-bin' /etc/mysql/mysql.conf.d/mysqld.cnf
 RUN RAND="$(date +%s | rev | cut -c 1-2)$(echo ${RANDOM})" && sed -i '/\[mysqld\]/a server-id='$RAND'\nlog-bin' /etc/mysql/mysql.conf.d/mysqld.cnf
 
 VOLUME /var/lib/mysql


### PR DESCRIPTION
Code Changes : 
----------------
The mysql-slave dockerfile uses the same server-id as the mysql-master in the following error during replication:

"Fatal error: The slave I/O thread stops because master and slave have equal MySQL server ids; these ids must be different for replication to work "

This commit removes that line & retains one that generates a random server-id

Fixes #23 