### PR TITLE
Initial commit to create stern-based debug container and kubernetes job 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -140,10 +140,19 @@ _push_tests_libiscsi_image:
 
 libiscsi: deps _build_tests_libiscsi_image _push_tests_libiscsi_image
 
-build: deps vdbench fio iometer k8s-client mysql-client tpcc-client custom-percona mysql-master mysql-slave sysbench-mongo libiscsi
+_build_logger_image:
+	@echo "INFO: Building container image for logger"
+	cd logger && docker build -t openebs/logger .
+
+_push_logger_image:
+	@echo "INFO: Publish container (openebs/logger)"
+	cd logger/buildscripts && ./push
+
+logger: deps _build_logger_image _push_logger_image
+
+build: deps vdbench fio iometer k8s-client mysql-client tpcc-client custom-percona mysql-master mysql-slave sysbench-mongo libiscsi logger 
 
 
-#
 # This is done to avoid conflict with a file of same name as the targets
 # mentioned in this makefile.
 #

--- a/custom-percona/Dockerfile
+++ b/custom-percona/Dockerfile
@@ -50,7 +50,7 @@ RUN set -ex; \
 RUN echo 'deb https://repo.percona.com/apt jessie main' > /etc/apt/sources.list.d/percona.list
 
 ENV PERCONA_MAJOR 5.7
-ENV PERCONA_VERSION 5.7.20-19-1.jessie
+ENV PERCONA_VERSION 5.7.21-20-1.jessie
 
 # the "/var/lib/mysql" stuff here is because the mysql-server postinst doesn't have an explicit way to disable the mysql_install_db codepath besides having a database already "configured" (ie, stuff in /var/lib/mysql/mysql)
 # also, we set debconf keys to make APT a little quieter

--- a/logger/Dockerfile
+++ b/logger/Dockerfile
@@ -1,0 +1,10 @@
+FROM ubuntu
+LABEL maintainer="OpenEBS"
+RUN apt-get update || true
+RUN apt-get install -y curl libgetopt++-dev 
+ENV KUBE_LATEST_VERSION="v1.8.2"
+RUN curl -L https://storage.googleapis.com/kubernetes-release/release/${KUBE_LATEST_VERSION}/bin/linux/amd64/kubectl -o /usr/local/bin/kubectl \
+ && chmod +x /usr/local/bin/kubectl 
+COPY stern /usr/local/bin
+COPY logger.sh /
+

--- a/logger/README.md
+++ b/logger/README.md
@@ -1,21 +1,29 @@
-### Introduction to Logger
+## OpenEBS Logger FAQ
 
-- The logger container and debugjob K8s job have been created to aid troubleshoot/debugging on 
-  the kubernetes cluster by capturing the pod logs 
+### What is OpenEBS Logger   
+
+- The logger is an Kubernetes job which can be run on the cluster to extract pod logs and 
+  cluster info. It has been created to aid troubleshoot/debugging activities.
+
+- It runs the logger container *openebs/logger*
+
+- Recommended to run for a specifc duration to capture logs on issue reproduction attempts 
+
+### How does the Logger work
+
 - Logger uses a tool called "stern" to collect the pod logs.
-- It is also capable of executing kubectl commands to extract cluster state.
 
-### Steps to run the OpenEBS Logger kubernetes job (debugjob)
+- It uses kubectl commands to extract cluster info.
 
-- Identify the path to the kubeconfig file & create a config map with its content. This is
-  required to be passed to the stern binary in order to collect the pod logs. Typically, the 
-  kubeconfig file is available at /etc/kubernetes/admin.conf OR ~/.kube/config. It may also
-  be obtained from the ENV on the master/deployment node.
+### What are the pre-requisites to run Logger 
 
-  `kubectl create configmap kubeconfig --from-file=<path-to-kubeconfig-file>`
+- Logger needs the kubeconfig file mounted as a configmap (passed to stern binary) 
+  Kubeconfig is generally found in /etc/kubernetes/admin.conf or ~/.kube/config
 
-- In the command to be executed, edit the logging duration & pod regex to reflect which pods' 
-  logs should be captured and for how long.
+### How to run the Logger 
+
+- In the logger job's command, edit the logging duration (-d) & pod regex (-r) to specify
+  which pods' logs should be captured and for how long.
 
   `./logger.sh -d 5 -r maya,openebs,pvc;` 
 

--- a/logger/README.md
+++ b/logger/README.md
@@ -1,0 +1,40 @@
+### Introduction to Logger
+
+- The logger container and debugjob K8s job have been created to aid troubleshoot/debugging on 
+  the kubernetes cluster by capturing the pod logs 
+- Logger uses a tool called "stern" to collect the pod logs.
+- It is also capable of executing kubectl commands to extract cluster state.
+
+### Steps to run the OpenEBS Logger kubernetes job (debugjob)
+
+- Identify the path to the kubeconfig file & create a config map with its content. This is
+  required to be passed to the stern binary in order to collect the pod logs. Typically, the 
+  kubeconfig file is available at /etc/kubernetes/admin.conf OR ~/.kube/config. It may also
+  be obtained from the ENV on the master/deployment node.
+
+  `kubectl create configmap kubeconfig --from-file=<path-to-kubeconfig-file>`
+
+- In the command to be executed, edit the logging duration & pod regex to reflect which pods' 
+  logs should be captured and for how long.
+
+  `./logger.sh -d 5 -r maya,openebs,pvc;` 
+
+  In the example above, the logs for pods starting with literals "maya", "openebs" and "pvc" are 
+  captured for a period of 5 min. 
+
+  Note: The duration is arrived upon depending on the average time taken for the "issue/bug" to
+  manifest from the time of pod start. 
+
+- Create the kubernetes job to run logger using the command `kubectl apply -f debugjob.yaml` 
+
+- This job will run for the duration specified in the previous steps
+
+- The logs collected in the manner described above are placed in a logbundle (tarball) in 
+  "/mnt" directory of the node in which the debug pod was scheduled
+
+- The node in which the debug pod/logger is scheduled & logs are available can be obtained by 
+  performing a `kubectl get pod -o wide` command. 
+
+- Attach this log support bundle while raising issues on the OpenEBS repository
+
+

--- a/logger/buildscripts/push
+++ b/logger/buildscripts/push
@@ -1,0 +1,14 @@
+#!/bin/bash
+set -e
+
+IMAGEID=$( docker images -q openebs/logger )
+
+if [ ! -z "${DNAME}" ] && [ ! -z "${DPASS}" ]; 
+then 
+  docker login -u "${DNAME}" -p "${DPASS}"; 
+  #Push to docker hub repository with latest tag
+  docker tag ${IMAGEID} openebs/logger:latest
+  docker push openebs/logger:latest; 
+else
+  echo "No docker credentials provided. Skip uploading openebs/logger:latest to docker hub"; 
+fi;

--- a/logger/debugjob.yaml
+++ b/logger/debugjob.yaml
@@ -11,9 +11,11 @@ spec:
       restartPolicy: Never
       containers:
       - name: debugjob
-        image: logger 
+        image: openebs/logger 
         imagePullPolicy: IfNotPresent
         command: ["/bin/bash"]
+        ## Specify duration in minutes
+        ## Provide a comma separated list of the pod literals
         args: ["-c", "./logger.sh -d 5 -r maya,openebs,pvc; exit 0"]
         volumeMounts:
         - name: kubeconfig 
@@ -24,10 +26,12 @@ spec:
         tty: true 
       volumes: 
         - name: kubeconfig
+          ## kubectl create configmap kubeconfig --from-file=<kubeconfig-file>
           configMap: 
             name: kubeconfig 
         - name: logs 
-          hostPath: 
+          ## Logs collected in /mnt/Logstash_<time_stamp>.tar 
+          hostPath:
             path: /mnt
             type: Directory 
 

--- a/logger/debugjob.yaml
+++ b/logger/debugjob.yaml
@@ -1,0 +1,34 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: debugjob
+spec:
+  template:
+    metadata:
+      name: debugjob
+    spec:
+      restartPolicy: Never
+      containers:
+      - name: debugjob
+        image: logger 
+        imagePullPolicy: IfNotPresent
+        command: ["/bin/bash"]
+        args: ["-c", "./logger.sh -d 5 -r maya,openebs,pvc; exit 0"]
+        volumeMounts:
+        - name: kubeconfig 
+          mountPath: /root/admin.conf
+          subPath: admin.conf
+        - name: logs
+          mountPath: /mnt 
+        tty: true 
+      volumes: 
+        - name: kubeconfig
+          configMap: 
+            name: kubeconfig 
+        - name: logs 
+          hostPath: 
+            path: /mnt
+            type: Directory 
+
+

--- a/logger/logger.sh
+++ b/logger/logger.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+#############################################################
+# This is a script that will run aggregate the logs of the 
+# kubernetes pods in the cluster. It also collects the ouput 
+# of certain kubectl commands that help in analyzing cluster
+# state. 
+#
+# TODO: Get node's systemd logs 
+#
+#############################################################
+
 function show_help(){
     cat << EOF
 Usage : $(basename "$0") -h help
@@ -10,7 +20,7 @@ Usage : $(basename "$0") -h help
 -d      Duration for log collection in minutes, ex: 10
 -r      Comma-separated string with starting literals of pod names, ex: pvc,maya
 
-Example: ./sternscript.sh -d 10 -r pvc,maya
+Example: ./logger.sh -d 10 -r pvc,maya,openebs
 EOF
 }
 

--- a/logger/logger.sh
+++ b/logger/logger.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+function show_help(){
+    cat << EOF
+Usage : $(basename "$0") -h help
+        $(basename "$0") -d <min>
+        $(basename "$0") -r <string>
+
+-h  	Display this help and exit
+-d      Duration for log collection in minutes, ex: 10
+-r      Comma-separated string with starting literals of pod names, ex: pvc,maya
+
+Example: ./sternscript.sh -d 10 -r pvc,maya
+EOF
+}
+
+if (($# == 0)); then
+    show_help
+    exit 2
+fi
+
+# Obtain the logging duration & pod-regex information
+while getopts ":h:d:r:" option  
+do
+    case $option in
+
+         h)  # Display help/usage 
+             show_help
+             exit
+             ;;
+   
+         d)  # Ensure duration is specified
+             # Set the sleep/wait variable
+             logtime=${OPTARG}
+             ;;
+        
+         r)  # Ensure that the pod regex is specified
+             # Set the stern regex string variable
+             podregex=`echo ${OPTARG} | sed 's/,/ /g'`
+             ;; 
+
+         *)  # Undesired arguments 
+             echo "Incorrect arguments provided, please check usage"
+             show_help
+             exit 1 
+             ;;
+    esac
+done 		 
+
+# kubectl command list
+declare -a kube_array=("kubectl get nodes"
+                       "kubectl get pods --all-namespaces"
+                       "kubectl get services"
+                       "kubectl get sc"
+                       "kubectl get pv"
+                       "kubectl get pvc")
+
+
+# Obtain cluster info via kubectl command outputs 
+for i in "${kube_array[@]}"
+do
+  strout='echo "### $i ###" && $i && echo "---"'
+  eval $strout >> /mnt/kubectl_cluster_info.log                           
+done
+
+# Instantiate stern logging on the selected pods w/ respective logfiles
+for i in $podregex; do
+    stern $i* --kubeconfig=/root/admin.conf > /mnt/$i.log 2>&1 &
+done 
+
+# Collect logs in the background for specified duration
+sleep $(($logtime*60)) 
+
+# Zip the pod logs & cleanup
+cd /mnt && tar -cvf Logstash_$(date +"%d_%m_%Y_%I_%M_%p").tar *.log && rm -f *.log 
+
+
+

--- a/mysql-master/Dockerfile
+++ b/mysql-master/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex; \
 	apt-key list > /dev/null
 
 ENV MYSQL_MAJOR 5.7
-ENV MYSQL_VERSION 5.7.20-1debian8
+ENV MYSQL_VERSION 5.7.21-1debian8
 
 RUN echo "deb http://repo.mysql.com/apt/debian/ jessie mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 

--- a/mysql-slave/Dockerfile
+++ b/mysql-slave/Dockerfile
@@ -42,7 +42,7 @@ RUN set -ex; \
 	apt-key list > /dev/null
 
 ENV MYSQL_MAJOR 5.7
-ENV MYSQL_VERSION 5.7.20-1debian8
+ENV MYSQL_VERSION 5.7.21-1debian8
 
 RUN echo "deb http://repo.mysql.com/apt/debian/ jessie mysql-${MYSQL_MAJOR}" > /etc/apt/sources.list.d/mysql.list
 


### PR DESCRIPTION
## Introduction to Logger

- The logger container and debugjob K8s job have been created to aid troubleshoot/debugging on the kubernetes cluster by capturing the pod logs
- Logger uses a tool called "stern" to collect the pod logs.
- It is also capable of executing kubectl commands to extract cluster state.

## Additional items 

Capabilities that need to be added (being worked currently) to the debug container to increase its effectiveness/utility include: 

- Collect node logs  (kubelet) 
- Capture kube-system logs (this can be obtained by passing --namespace arg to stern. However, this may need to be an optional param)
